### PR TITLE
テキストボックスの改行処理の修正

### DIFF
--- a/Assets/Sources/Novel/Command/TextCommand/maintext/MAINTEXT_Skip.cs
+++ b/Assets/Sources/Novel/Command/TextCommand/maintext/MAINTEXT_Skip.cs
@@ -48,6 +48,9 @@ namespace AdolescenceNovel
             int length = tmpStr.Length;
             for (; MAINTEXT_Write.singleton.characterNum < length;)
             {
+                bool checkAdd = false;
+                bool checkAddChar = false;
+                string add_last = "";
 
                 MAINTEXT_Write.singleton.character_now++;
                 char nowChar = tmpStr[MAINTEXT_Write.singleton.characterNum++];
@@ -59,7 +62,13 @@ namespace AdolescenceNovel
                         MAINTEXT_Write.singleton.check_return = true;
                         if (length - MAINTEXT_Write.singleton.characterNum > 3)
                         {
-                            TextData.instance.textbox[ConstData.TextboxMain].text.text += '\n';
+                            checkAdd = true;
+                            if (tmpStr[MAINTEXT_Write.singleton.characterNum] == '、' || tmpStr[MAINTEXT_Write.singleton.characterNum] == '。')
+                            {
+                                checkAddChar = true;
+                                add_last += tmpStr[MAINTEXT_Write.singleton.characterNum];
+                            }
+                            add_last += '\n';
                             MAINTEXT_Write.singleton.character_now = 0;
                         }
                     }
@@ -70,7 +79,16 @@ namespace AdolescenceNovel
                     {
                         if (length - MAINTEXT_Write.singleton.characterNum > 3)
                         {
-                            TextData.instance.textbox[ConstData.TextboxMain].text.text += '\n';
+                            checkAdd = true;
+                            if (MAINTEXT_Write.singleton.characterNum != tmpStr.Length)
+                            {
+                                if (tmpStr[MAINTEXT_Write.singleton.characterNum] == '、' || tmpStr[MAINTEXT_Write.singleton.characterNum] == '。')
+                                {
+                                    checkAddChar = true;
+                                    add_last += tmpStr[MAINTEXT_Write.singleton.characterNum];
+                                }
+                            }
+                            add_last += '\n';
                             MAINTEXT_Write.singleton.character_now = 0;
                         }
                     }
@@ -105,6 +123,14 @@ namespace AdolescenceNovel
                     default:
                         TextData.instance.textbox[ConstData.TextboxMain].text.text += nowChar + TextData.SetRubyOffset_Vertical();
                         break;
+                }
+                if (checkAdd)
+                {
+                    TextData.instance.textbox[ConstData.TextboxMain].text.text += add_last;
+                    if (checkAddChar)
+                    {
+                        MAINTEXT_Write.singleton.characterNum++;
+                    }
                 }
             }
             context.ChangeStatus(new MAINTEXT_Write());

--- a/Assets/Sources/Novel/Command/TextCommand/maintext/MAINTEXT_Write.cs
+++ b/Assets/Sources/Novel/Command/TextCommand/maintext/MAINTEXT_Write.cs
@@ -59,6 +59,7 @@ namespace AdolescenceNovel
         {
             string tmpStr = (string)nowstate.text.Value();
             int length = tmpStr.Length;
+            bool rubyCheck = false;
             //Submitが入力された場合に入力待ちまで飛ばす
             if (KeyConfig.instance.CheckSubmit() || KeyConfig.instance.CheckNovelSkip())
             {
@@ -94,7 +95,6 @@ namespace AdolescenceNovel
                                 add_last += tmpStr[singleton.characterNum];
                             }
                             add_last += '\n';
-                            singleton.character_now = 0;
                         }
                     }
                 }
@@ -114,7 +114,6 @@ namespace AdolescenceNovel
                                 }
                             }
                             add_last += '\n';
-                            singleton.character_now = 0;
                         }
                     }
                 }
@@ -125,7 +124,7 @@ namespace AdolescenceNovel
                         context.ChangeStatus(new MAINTEXT_Wait());
                         break;
                     case '(':
-                        context.ChangeStatus(new MAINTEXT_Ruby(singleton.characterNum, tmpStr));
+                        rubyCheck = true;
                         break;
                     case '{':
                         context.ChangeStatus(new MAINTEXT_Variable());
@@ -141,11 +140,16 @@ namespace AdolescenceNovel
                 }
                 if (checkAdd)
                 {
+                    singleton.character_now = 0;
                     TextData.instance.textbox[ConstData.TextboxMain].text.text += add_last;
                     if (checkAddChar)
                     {
                         singleton.characterNum++;
                     }
+                }
+                if (rubyCheck)
+                {
+                    context.ChangeStatus(new MAINTEXT_Ruby(singleton.characterNum, tmpStr));
                 }
             }
             singleton.nowTime += (int)(Time.deltaTime * 1000);


### PR DESCRIPTION
テキストボックスにおける改行処理において、ルビ振りを行う処理と改行処理が同時に起こった際に改行がされないというバグがあったため、その修正を行った。